### PR TITLE
受講生情報を登録して追加後の受講生一覧を表示

### DIFF
--- a/src/main/java/raisetech/studentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentManagement/controller/StudentController.java
@@ -4,10 +4,17 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import raisetech.studentManagement.controller.converter.StudentConverter;
 import raisetech.studentManagement.data.Student;
 import raisetech.studentManagement.data.StudentCourses;
+import raisetech.studentManagement.domain.StudentDetail;
+import raisetech.studentManagement.repository.StudentRepository;
 import raisetech.studentManagement.service.StudentService;
 
 @Controller
@@ -15,11 +22,13 @@ public class StudentController {
 
   private StudentService service;
   private StudentConverter converter;
+  private StudentRepository repository;
 
   @Autowired
-  public StudentController(StudentService service, StudentConverter converter) {
+  public StudentController(StudentService service, StudentConverter converter, StudentRepository repository) {
     this.service = service;
     this.converter = converter;
+    this.repository = repository;
 
   } //受講生に紐付けた情報を取得
 
@@ -41,5 +50,39 @@ public class StudentController {
   public List<StudentCourses> searchStudentCoursesList() {
     return service.searchStudentCoursesList();
   }
-}
 
+  @GetMapping("/newStudent")
+  public String newStudent(Model model){
+    model.addAttribute("studentDetail", new StudentDetail());
+    return "registerStudent";
+  }
+//新規登録
+  @PostMapping("/registerStudent")
+  public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      //エラー
+      return "resisterStudent";
+    }
+    repository.resisterStudent(studentDetail.getStudent().getName(),
+        studentDetail.getStudent().getFurigana(),studentDetail.getStudent().getNickname(),
+        studentDetail.getStudent().getEmail(),studentDetail.getStudent().getCity(),studentDetail.getStudent().getAge(),
+        studentDetail.getStudent().getGender(),studentDetail.getStudent().getRemarks());
+
+    //新規受講生情報を登録する処理の実装
+    //コース情報も登録できるように実装
+
+
+    System.out.println(
+        studentDetail.getStudent().getName() + "さんが受講生として新規登録されました");
+    return "redirect:/studentList";
+  }
+  @PatchMapping("/student")
+  public void updateStudentName(String name, int age) {
+    repository.updateStudent(name, age);
+  }
+
+  @DeleteMapping("/student")
+  public void deleteStudent(String name) {
+    repository.deleteStudent(name);
+  }
+}

--- a/src/main/java/raisetech/studentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/studentManagement/repository/StudentRepository.java
@@ -1,18 +1,32 @@
 package raisetech.studentManagement.repository;
 
 import java.util.List;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import raisetech.studentManagement.data.Student;
 import raisetech.studentManagement.data.StudentCourses;
 
 @Mapper
 public interface StudentRepository {
-//DBから情報の取得
+
+  //DBから情報の取得
   @Select("SELECT * FROM students")
   List<Student> search();
 
   @Select("SELECT * FROM courses")
   List<StudentCourses> searchCourses();
+
+  @Insert("INSERT students (name,furigana,nickname,email,city,age,gender,remarks) VALUES(#{name},#{furigana},#{nickname},#{email},#{city},#{age},#{gender},#{remarks})")
+  void resisterStudent(String name,String furigana, String nickname, String email,String city,
+      int age, String gender, String remarks);
+
+  @Update("UPDATE student SET age = #{age} WHERE name = #{name}")
+  void updateStudent(String name, int age);
+
+  @Delete("DELETE FROM student WHERE name =#{name}")
+  void deleteStudent(String name);
 
 }

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:th = "http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生登録</title>
+</head>
+<body>
+<h1>受講生登録</h1>
+<form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="name">名前</label>
+    <input type="text" id="name" th:field="*{student.name}" required/>
+  </div>
+  <div>
+    <label for="furigana">フリガナ</label>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
+  </div>
+  <div>
+    <label for="nickname">ニックネーム</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}" required/>
+  </div>
+  <div>
+    <label for="email">email</label>
+    <input type="text" id="email" th:field="*{student.email}" required/>
+  </div>
+  <div>
+    <label for="city">お住まいの市町村</label>
+    <input type="text" id="city" th:field="*{student.city}" required/>
+  </div>
+  <div>
+    <label for="age">年齢</label>
+    <input type="number" id="age" min="0" max="120" th:field="*{student.age}" required/>
+  </div>
+  <div>
+    <label for="gender">性別</label>
+    <select id="gender" th:field="*{student.gender}" required/>
+      <option value="male">男性</option>
+      <option value="female">女性</option>
+      <option value="other">その他</option>
+    </select>
+  </div>
+  <div>
+    <label for="remarks">備考</label>
+    <input type="text" id="remarks" th:field="*{student.remarks}" required/>
+  </div>
+  <button type="submit">登録</button>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -31,14 +31,8 @@
     <td th:text="${studentDetail.student.age}">5０</td>
     <td th:text="${studentDetail.student.gender}">male</td>
     <td th:text="${studentDetail.student.remarks}">特になし</td>
-
   </tr>
-
   </tbody>
-
-
-
-
 </table>
 </body>
 </html>


### PR DESCRIPTION
## 実装概要
受講生情報をブラウザで入力し、登録できるように変更した。
追加後の受講生一覧を表示させる。

## 動作確認


![スクリーンショット 2024-12-13 234431](https://github.com/user-attachments/assets/459c9a97-ec46-4bc5-8dec-80e8b7e11e81)

![スクリーンショット 2024-12-13 233649](https://github.com/user-attachments/assets/98b34a8e-80d9-4499-b800-f77f78c0ceda)

## 差分

c926c5357ef6f32f878763a8b6837fa7c1816cf7