### PR TITLE
受講生の論理削除実装

### DIFF
--- a/src/main/java/raisetech/studentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/studentManagement/repository/StudentRepository.java
@@ -14,6 +14,9 @@ import raisetech.studentManagement.data.StudentsCourses;
 @Mapper
 public interface StudentRepository {
 
+  //DELETE　　WHERE is_deleted = falseを条件で指定すると画面で確認できなくなる為、今回は指定しない。
+ // @Select("SELECT * FROM students")
+
   //DBから情報の取得
   @Select("SELECT * FROM students")
   List<Student> search();

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -18,6 +18,7 @@
   <th>年齢</th>
   <th>性別</th>
   <th>備考</th>
+  <th>キャンセル</th>
   </tr>
   </thead>
   <tbody>
@@ -34,6 +35,9 @@
     <td th:text="${studentDetail.student.age}">5０</td>
     <td th:text="${studentDetail.student.gender}">male</td>
     <td th:text="${studentDetail.student.remarks}">特になし</td>
+    <td>
+      <input type="checkbox" th:checked="${studentDetail.student.isDeleted}"/>
+    </td>
   </tr>
   </tbody>
 </table>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -40,14 +40,22 @@
     <input id="gender" th:field="*{student.gender}" required/>
   </div>
   <div th:each="course, stat : *{studentsCourses}">
-    <label for="id"
+    <label for="studentCourseId"
            th:for="studentCourse.__${stat.index}__.id">受講コースID：</label>
-    <input type="text" id="id" th:id="studentCourse.__${stat.index}__.id"
+    <input type="text" id="studentCourseId" th:id="studentCourse.__${stat.index}__.id"
            th:field="*{studentsCourses[__${stat.index}__].id}"/>
     <label for="courseName"
            th:for="studentCourse.__${stat.index}__.courseName">受講コース名：</label>
     <input type="text" id="courseName" th:id="studentCourse.__${stat.index}__.courseName"
            th:field="*{studentsCourses[__${stat.index}__].courseName}"/>
+  </div>
+  <div>
+  <label for="remarks">備考</label>
+  <input id="remarks" th:field="*{student.remarks}"/>
+</div>
+  <div>
+    <label for="isDeleted">キャンセル</label>
+    <input type="checkbox" id="isDeleted" th:field="*{student.deleted}"/>
   </div>
     <button type="submit">更新</button>
 </form>


### PR DESCRIPTION
## 変更の概要
受講生の論理削除を実装

## 動作確認
受講生情報の一覧初期画面
![スクリーンショット 2024-12-17 232841](https://github.com/user-attachments/assets/5ea30148-8487-4111-875d-81008b6d1ba4)


受講生詳細画面にてキャンセルボタン押下（isDeletedがtrueになる）

![スクリーンショット 2024-12-17 232852](https://github.com/user-attachments/assets/3fb20694-20d3-4977-a854-22467a14e259)


受講生一覧表示画面に反映
![スクリーンショット 2024-12-17 232859](https://github.com/user-attachments/assets/be168d2e-8be9-4ac2-90d6-be4b60e950e0)


## 差分
a33311ca06930a7952b33527a996e23e4bbf76a2